### PR TITLE
Fix celerybeat supervisord conf

### DIFF
--- a/.ac_mariner_proj/Dockerfile
+++ b/.ac_mariner_proj/Dockerfile
@@ -80,7 +80,12 @@ RUN chmod +x ${ARCHES_ROOT}/arches/install/arches_admin.py
 
 RUN pip install --upgrade pip setuptools wheel
 
-# Install the mariner_app package first
+# Install the project
+COPY ./${PROJ_NAME} ${APP_ROOT}
+WORKDIR ${APP_ROOT}
+RUN pip install -e '.[dev]'
+
+# Install the mariner_app package in editable mode
 ENV MARINER_APP=${WEB_ROOT}/mariner_app
 COPY $MARINER_APP_PATH ${MARINER_APP}
 WORKDIR ${MARINER_APP}

--- a/.ac_mariner_proj/docker/conf.d/celerybeat.conf
+++ b/.ac_mariner_proj/docker/conf.d/celerybeat.conf
@@ -3,20 +3,21 @@
 ; ================================
 
 [program:celerybeat]
-	command=celery -A mariner_proj.celery beat --schedule=/tmp/celerybeat-schedule --loglevel=INFO --pidfile=/tmp/celerybeat.pid
-	directory=/web_root/mariner_proj
+command=celery -A mariner_proj.celery beat --loglevel=INFO --pidfile=/tmp/celerybeat.pid --schedule=/tmp/celerybeat-schedule
+directory=/web_root/mariner_proj
+user=root
+numprocs=1
+stdout_logfile=/var/log/celery/beat.log
+stderr_logfile=/var/log/celery/beat.log
+autostart=true
+autorestart=true
+startsecs=60
+; Need to wait for currently executing tasks to finish at shutdown.
+; Increase this if you have very long running tasks.
+stopwaitsecs = 600
 
-    user=root
-    numprocs=1
-    stdout_logfile=/var/log/celery/beat.log
-    stderr_logfile=/var/log/celery/beat.log
-    autostart=true
-    autorestart=true
-    startsecs=10
-
-    ; Causes supervisor to send the termination signal (SIGTERM) to the whole process group.
-    stopasgroup=true
-
-    ; if rabbitmq is supervised, set its priority higher
-    ; so it starts first
-    priority=999
+; Causes supervisor to send the termination signal (SIGTERM) to the whole process group.
+stopasgroup=true
+; if rabbitmq is supervised, set its priority higher
+; so it starts first
+priority=999

--- a/.ac_mariner_proj/docker/conf.d/celeryd.conf
+++ b/.ac_mariner_proj/docker/conf.d/celeryd.conf
@@ -3,24 +3,20 @@
 ; ==================================
 
 [program:celery]
-    command=celery -A mariner_proj.celery worker --loglevel=INFO
-    directory=/web_root/mariner_proj
-
-    user=root
-    numprocs=1
-    stdout_logfile=/var/log/celery/worker.log
-    stderr_logfile=/var/log/celery/worker.log
-    autostart=true
-    autorestart=true
-    startsecs=10
-
-    ; Need to wait for currently executing tasks to finish at shutdown.
-    ; Increase this if you have very long running tasks.
-    stopwaitsecs = 600
-
-    ; Causes supervisor to send the termination signal (SIGTERM) to the whole process group.
-    stopasgroup=true
-
-    ; Set Celery priority higher than default (999)
-    ; so, if rabbitmq is supervised, it will start first.
-    priority=1000
+command=celery -A mariner_proj.celery worker --loglevel=INFO
+directory=/web_root/mariner_proj
+user=root
+numprocs=1
+stdout_logfile=/var/log/celery/worker.log
+stderr_logfile=/var/log/celery/worker.log
+autostart=true
+autorestart=true
+startsecs=10
+; Need to wait for currently executing tasks to finish at shutdown.
+; Increase this if you have very long running tasks.
+stopwaitsecs = 600
+; Causes supervisor to send the termination signal (SIGTERM) to the whole process group.
+stopasgroup=true
+; Set Celery priority higher than default (999)
+; so, if rabbitmq is supervised, it will start first.
+priority=1000

--- a/.ac_mariner_proj/docker/supervisor.conf
+++ b/.ac_mariner_proj/docker/supervisor.conf
@@ -1,24 +1,29 @@
 [unix_http_server]
-    file=/tmp/supervisor.sock   ; path to your socket file
-    chmod=7770
+file=/tmp/supervisor.sock   ; path to your socket file
+chmod=7770
+
+[inet_http_server]
+port=0.0.0.0:9001
+username=user
+password=pass
 
 [supervisord]
-    logfile=/var/log/supervisor/supervisord.log ; supervisord log file
-    logfile_maxbytes=50MB       ; maximum size of logfile before rotation
-    logfile_backups=10          ; number of backed up logfiles
-    loglevel=info               ; info, debug, warn, trace
-    pidfile=/var/run/supervisord.pid ; pidfile location
-    nodaemon=false              ; run supervisord as a daemon
-    minfds=1024                 ; number of startup file descriptors
-    minprocs=200                ; number of process descriptors
-    user=root           ; defaults to whichever user is runs supervisor
-    childlogdir=/var/log/supervisor/            ; where child log files will live
+logfile=/var/log/supervisor/supervisord.log ; supervisord log file
+logfile_maxbytes=50MB       ; maximum size of logfile before rotation
+logfile_backups=10          ; number of backed up logfiles
+loglevel=info               ; info, debug, warn, trace
+pidfile=/var/run/supervisord.pid ; pidfile location
+nodaemon=false              ; run supervisord as a daemon
+minfds=1024                 ; number of startup file descriptors
+minprocs=200                ; number of process descriptors
+user=root           ; defaults to whichever user is runs supervisor
+childlogdir=/var/log/supervisor/            ; where child log files will live
 
 [rpcinterface:supervisor]
-    supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-    serverurl=unix:///tmp/supervisor.sock ; use unix:// schem for a unix sockets.
+serverurl=unix:///tmp/supervisor.sock ; use unix:// schem for a unix sockets.
 
 [include]
-    files=./conf.d/*.conf
+files=./conf.d/*.conf


### PR DESCRIPTION
This pull request includes several updates to the Docker configuration files for the `mariner_proj`. The changes primarily focus on improving the setup and configuration of Celery and Supervisor.

### Dockerfile updates:
* Added steps to copy the project files and install the project in editable mode (`.ac_mariner_proj/Dockerfile`).

### Celery configuration updates:
* Reordered and modified the Celery beat command, increased the `startsecs` value, and added `stopwaitsecs` to allow for task completion before shutdown (`.ac_mariner_proj/docker/conf.d/celerybeat.conf`).
* Added `stopwaitsecs` to the Celery worker configuration to ensure tasks finish before shutdown (`.ac_mariner_proj/docker/conf.d/celeryd.conf`).

### Supervisor configuration updates:
* Added an `inet_http_server` section to the Supervisor configuration for remote access and management (`.ac_mariner_proj/docker/supervisor.conf`).

### ACT usage for checking.

If you are already using ACT, you'll need to use `act import` to pull in the new Dockerfile and and then run `act up -b` to force the mariner_proj dev image to rebuild.

Once running you can shell into the container and use `top` and then type `c` to see the running processes.