### PR TITLE
Initial migrations to handle mariner sandbox restore AB#84748

### DIFF
--- a/mariner_proj/migrations/84748_mariner_restore_steps.py
+++ b/mariner_proj/migrations/84748_mariner_restore_steps.py
@@ -33,7 +33,7 @@ class Migration(migrations.Migration):
         """
         # Update languageid to 'en-us'
         Value = apps.get_model("models", "Value")
-        Value.objects.filter(language_id='en-US').update(language_id='en-us')
+        Value.objects.filter(language_id="en-US").update(language_id="en-us")
 
         # Drop schemas if they exist
         schemas_to_drop = [
@@ -48,7 +48,7 @@ class Migration(migrations.Migration):
             "period",
             "person",
             "place",
-            "wreck_site"
+            "wreck_site",
         ]
         for schema in schemas_to_drop:
             schema_editor.execute(f"DROP SCHEMA IF EXISTS {schema} CASCADE")

--- a/mariner_proj/migrations/84748_mariner_restore_steps.py
+++ b/mariner_proj/migrations/84748_mariner_restore_steps.py
@@ -1,0 +1,58 @@
+"""
+DROP SCHEMA IF EXISTS activity CASCADE;
+DROP SCHEMA IF EXISTS aircraft_crash_site CASCADE;
+DROP SCHEMA IF EXISTS artefact CASCADE;
+DROP SCHEMA IF EXISTS bibliographic_source CASCADE;
+DROP SCHEMA IF EXISTS historic_aircraft CASCADE;
+DROP SCHEMA IF EXISTS maritime_vessel CASCADE;
+DROP SCHEMA IF EXISTS monument CASCADE;
+DROP SCHEMA IF EXISTS organization CASCADE;
+DROP SCHEMA IF EXISTS period CASCADE;
+DROP SCHEMA IF EXISTS person CASCADE;
+DROP SCHEMA IF EXISTS place CASCADE;
+DROP SCHEMA IF EXISTS wreck_site CASCADE;
+"""
+
+from django.db import migrations
+from django.utils.translation import gettext as _
+from arches.app.models.system_settings import settings
+from django.contrib.auth.models import User
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    run_before = [
+        ("models", "6458_language"),
+    ]
+
+    def fix_data_after_restore(apps, schema_editor):
+        """
+        Fix data after restore
+        """
+        # Update languageid to 'en-us'
+        Value = apps.get_model("models", "Value")
+        Value.objects.filter(language_id='en-US').update(language_id='en-us')
+
+        # Drop schemas if they exist
+        schemas_to_drop = [
+            "activity",
+            "aircraft_crash_site",
+            "artefact",
+            "bibliographic_source",
+            "historic_aircraft",
+            "maritime_vessel",
+            "monument",
+            "organization",
+            "period",
+            "person",
+            "place",
+            "wreck_site"
+        ]
+        for schema in schemas_to_drop:
+            schema_editor.execute(f"DROP SCHEMA IF EXISTS {schema} CASCADE")
+
+    operations = [
+        migrations.RunPython(fix_data_after_restore),
+    ]

--- a/mariner_proj/migrations/84748_publish_graphs_after_restore.py
+++ b/mariner_proj/migrations/84748_publish_graphs_after_restore.py
@@ -1,0 +1,94 @@
+from django.db import migrations
+from django.utils import translation
+from django.utils.translation import gettext as _
+from arches.app.models.system_settings import settings
+from arches.app.models.resource import UnpublishedModelError
+from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
+import uuid
+import datetime
+
+def publish_proxy(apps, graph, user, notes=None):
+        """
+        proxy the code for graph.publish at 7.6
+        apps.get_model only provides the historical model without
+        the instance code.
+        """
+        self = graph
+
+        GraphXPublishedGraph = apps.get_model("models", "GraphXPublishedGraph")
+        Language = apps.get_model("models", "Language")
+        PublishedGraph = apps.get_model("models", "PublishedGraph")
+
+        try:
+            publication = GraphXPublishedGraph.objects.create(
+                graph=self,
+                notes=notes,
+                user=user,
+            )
+            publication.save()
+
+            self.publication = publication
+            self.save()
+
+            for language_tuple in settings.LANGUAGES:
+                language = Language.objects.get(code=language_tuple[0])
+
+                translation.activate(language=language_tuple[0])
+
+                published_graph = PublishedGraph.objects.create(
+                    publication=publication,
+                    serialized_graph=JSONDeserializer().deserialize(
+                        JSONSerializer().serialize(self, force_recalculation=True)
+                    ),
+                    language=language,
+                )
+
+                published_graph.save()
+
+            translation.deactivate()
+        except Exception as e:
+                print(f"Error publishing graph {self.name}:", e)
+                raise UnpublishedModelError(e)
+
+
+def publish_graphs_after_restore(apps, schema_editor):
+    """
+    Publish all graphs after restore by creating GraphXPublishedGraph entries
+    """
+    system_settings_id = settings.SYSTEM_SETTINGS_RESOURCE_MODEL_ID
+    Graph = apps.get_model("models", "GraphModel")
+        
+    # Use the admin user for the publication process
+    User = apps.get_model("auth", "User")
+    try:
+        system_user = User.objects.get(username='admin')
+    except User.DoesNotExist:
+        # Fall back to any superuser if 'admin' does not exist
+        system_user = User.objects.filter(is_superuser=True).first()
+        if not system_user:
+            raise Exception("No superuser found to publish graphs.")
+        
+
+    # Get all unpublished resource graphs excluding the system settings model
+    graphs_to_publish = Graph.objects.filter(
+        isresource=True,
+        publication__isnull=True
+    ).exclude(graphid=system_settings_id)
+    
+    # Publish each graph by creating a GraphXPublishedGraph entry
+    for graph in graphs_to_publish:
+        publish_proxy(apps, graph, system_user, notes=_("Published after restore"))
+
+
+class Migration(migrations.Migration):
+
+    initial = False
+
+    dependencies = [
+        ("mariner_app", "84748_initial_bng_photo_datatype_functions_widgets"),
+        ("mariner_proj", "84748_mariner_restore_steps")
+    ]
+
+    operations = [
+        migrations.RunPython(publish_graphs_after_restore),
+    ]

--- a/mariner_proj/migrations/84748_publish_graphs_after_restore.py
+++ b/mariner_proj/migrations/84748_publish_graphs_after_restore.py
@@ -7,75 +7,76 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 import uuid
 import datetime
 
+
 def publish_proxy(apps, graph, user, notes=None):
-        """
-        proxy the code for graph.publish at 7.6
-        apps.get_model only provides the historical model without
-        the instance code.
-        """
-        self = graph
+    """
+    Proxy the code for arches.app.models.Graph.publish() at 7.6.x
 
-        GraphXPublishedGraph = apps.get_model("models", "GraphXPublishedGraph")
-        Language = apps.get_model("models", "Language")
-        PublishedGraph = apps.get_model("models", "PublishedGraph")
+    `apps.get_model` only provides the historical model without
+    the instance code.
 
-        try:
-            publication = GraphXPublishedGraph.objects.create(
-                graph=self,
-                notes=notes,
-                user=user,
+    """
+    self = graph
+
+    GraphXPublishedGraph = apps.get_model("models", "GraphXPublishedGraph")
+    Language = apps.get_model("models", "Language")
+    PublishedGraph = apps.get_model("models", "PublishedGraph")
+
+    try:
+        publication = GraphXPublishedGraph.objects.create(
+            graph=self,
+            notes=notes,
+            user=user,
+        )
+        publication.save()
+
+        self.publication = publication
+        self.save()
+
+        for language_tuple in settings.LANGUAGES:
+            language = Language.objects.get(code=language_tuple[0])
+
+            translation.activate(language=language_tuple[0])
+
+            published_graph = PublishedGraph.objects.create(
+                publication=publication,
+                serialized_graph=JSONDeserializer().deserialize(
+                    JSONSerializer().serialize(self, force_recalculation=True)
+                ),
+                language=language,
             )
-            publication.save()
 
-            self.publication = publication
-            self.save()
+            published_graph.save()
 
-            for language_tuple in settings.LANGUAGES:
-                language = Language.objects.get(code=language_tuple[0])
-
-                translation.activate(language=language_tuple[0])
-
-                published_graph = PublishedGraph.objects.create(
-                    publication=publication,
-                    serialized_graph=JSONDeserializer().deserialize(
-                        JSONSerializer().serialize(self, force_recalculation=True)
-                    ),
-                    language=language,
-                )
-
-                published_graph.save()
-
-            translation.deactivate()
-        except Exception as e:
-                print(f"Error publishing graph {self.name}:", e)
-                raise UnpublishedModelError(e)
+        translation.deactivate()
+    except Exception as e:
+        print(f"Error publishing graph {self.name}:", e)
+        raise UnpublishedModelError(e)
 
 
 def publish_graphs_after_restore(apps, schema_editor):
     """
-    Publish all graphs after restore by creating GraphXPublishedGraph entries
+    Publish all graphs after restore
     """
     system_settings_id = settings.SYSTEM_SETTINGS_RESOURCE_MODEL_ID
     Graph = apps.get_model("models", "GraphModel")
-        
+
     # Use the admin user for the publication process
     User = apps.get_model("auth", "User")
     try:
-        system_user = User.objects.get(username='admin')
+        system_user = User.objects.get(username="admin")
     except User.DoesNotExist:
         # Fall back to any superuser if 'admin' does not exist
         system_user = User.objects.filter(is_superuser=True).first()
         if not system_user:
             raise Exception("No superuser found to publish graphs.")
-        
 
     # Get all unpublished resource graphs excluding the system settings model
     graphs_to_publish = Graph.objects.filter(
-        isresource=True,
-        publication__isnull=True
+        isresource=True, publication__isnull=True
     ).exclude(graphid=system_settings_id)
-    
-    # Publish each graph by creating a GraphXPublishedGraph entry
+
+    # Publish each graph using proxy function
     for graph in graphs_to_publish:
         publish_proxy(apps, graph, system_user, notes=_("Published after restore"))
 
@@ -86,7 +87,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("mariner_app", "84748_initial_bng_photo_datatype_functions_widgets"),
-        ("mariner_proj", "84748_mariner_restore_steps")
+        ("mariner_proj", "84748_mariner_restore_steps"),
     ]
 
     operations = [


### PR DESCRIPTION
This pull request includes significant changes to the database migration process in the `mariner_proj` project. The changes focus on restoring and publishing data after a database restore operation. Below are the most important changes:

Database schema restoration:

* [`mariner_proj/migrations/84748_mariner_restore_steps.py`](diffhunk://#diff-c7d5c99971fda30b201de7e88646765acc8efdd2b216f238b0c1caaba757dabdR1-R58): Added a migration to drop specific schemas if they exist and update language IDs to a consistent format after a restore operation.

Publishing graphs after restore:

* [`mariner_proj/migrations/84748_publish_graphs_after_restore.py`](diffhunk://#diff-06a65f7a2e35b97e2fdc789821d4b25b23b90cdbbf3bedd6b9dff5766064b4ddR1-R95): Added a migration to publish all resource graphs after a restore operation, using a proxy function to handle the publication process. This includes handling potential exceptions and ensuring a superuser is available for the publication.