### PR TITLE
Fix publish graph migration step AB#84748

### DIFF
--- a/mariner_proj/migrations/84748_publish_graphs_after_restore.py
+++ b/mariner_proj/migrations/84748_publish_graphs_after_restore.py
@@ -1,57 +1,13 @@
 from django.db import migrations
 from django.utils import translation
+from django.contrib.auth.models import User
 from django.utils.translation import gettext as _
 from arches.app.models.system_settings import settings
 from arches.app.models.resource import UnpublishedModelError
+from arches.app.models.graph import Graph
 from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializer
 import uuid
 import datetime
-
-
-def publish_proxy(apps, graph, user, notes=None):
-    """
-    Proxy the code for arches.app.models.Graph.publish() at 7.6.x
-
-    `apps.get_model` only provides the historical model without
-    the instance code.
-
-    """
-    self = graph
-
-    GraphXPublishedGraph = apps.get_model("models", "GraphXPublishedGraph")
-    Language = apps.get_model("models", "Language")
-    PublishedGraph = apps.get_model("models", "PublishedGraph")
-
-    try:
-        publication = GraphXPublishedGraph.objects.create(
-            graph=self,
-            notes=notes,
-            user=user,
-        )
-        publication.save()
-
-        self.publication = publication
-        self.save()
-
-        for language_tuple in settings.LANGUAGES:
-            language = Language.objects.get(code=language_tuple[0])
-
-            translation.activate(language=language_tuple[0])
-
-            published_graph = PublishedGraph.objects.create(
-                publication=publication,
-                serialized_graph=JSONDeserializer().deserialize(
-                    JSONSerializer().serialize(self, force_recalculation=True)
-                ),
-                language=language,
-            )
-
-            published_graph.save()
-
-        translation.deactivate()
-    except Exception as e:
-        print(f"Error publishing graph {self.name}:", e)
-        raise UnpublishedModelError(e)
 
 
 def publish_graphs_after_restore(apps, schema_editor):
@@ -59,10 +15,7 @@ def publish_graphs_after_restore(apps, schema_editor):
     Publish all graphs after restore
     """
     system_settings_id = settings.SYSTEM_SETTINGS_RESOURCE_MODEL_ID
-    Graph = apps.get_model("models", "GraphModel")
 
-    # Use the admin user for the publication process
-    User = apps.get_model("auth", "User")
     try:
         system_user = User.objects.get(username="admin")
     except User.DoesNotExist:
@@ -78,8 +31,16 @@ def publish_graphs_after_restore(apps, schema_editor):
 
     # Publish each graph using proxy function
     for graph in graphs_to_publish:
-        publish_proxy(apps, graph, system_user, notes=_("Published after restore"))
-
+        #publish_proxy(apps, graph, system_user, notes=_("Published after restore"))
+        try:
+            graph.publish(
+                user=system_user,
+                notes=_("Published after restore"),
+            )
+        except Exception as e:
+            raise UnpublishedModelError(e)
+        
+        
 
 class Migration(migrations.Migration):
 

--- a/mariner_proj/migrations/84748_publish_graphs_after_restore.py
+++ b/mariner_proj/migrations/84748_publish_graphs_after_restore.py
@@ -9,6 +9,10 @@ from arches.app.utils.betterJSONSerializer import JSONSerializer, JSONDeserializ
 import uuid
 import datetime
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 def publish_graphs_after_restore(apps, schema_editor):
     """
@@ -24,23 +28,20 @@ def publish_graphs_after_restore(apps, schema_editor):
         if not system_user:
             raise Exception("No superuser found to publish graphs.")
 
-    # Get all unpublished resource graphs excluding the system settings model
     graphs_to_publish = Graph.objects.filter(
         isresource=True, publication__isnull=True
     ).exclude(graphid=system_settings_id)
 
-    # Publish each graph using proxy function
     for graph in graphs_to_publish:
-        #publish_proxy(apps, graph, system_user, notes=_("Published after restore"))
         try:
             graph.publish(
                 user=system_user,
                 notes=_("Published after restore"),
             )
         except Exception as e:
+            logger.error(f"Failed to publish graph {graph.graphid}: {e}")
             raise UnpublishedModelError(e)
-        
-        
+
 
 class Migration(migrations.Migration):
 


### PR DESCRIPTION
Reverted from historical graph models to Graph proxy model as the publish process needs the proxy functions to serialize everything that's needed.

**:octocat: copilot summary**

This pull request includes significant changes to the `mariner_proj/migrations/84748_publish_graphs_after_restore.py` file. The most important changes involve the removal of a proxy function and the direct use of the `publish` method from the `Graph` model. 

Key changes include:

### Removal of Proxy Function:
* The `publish_proxy` function, which was used to publish graphs, has been removed. This function was responsible for creating a publication record, saving it, and handling the publication for different languages.

### Direct Use of `publish` Method:
* The `publish_graphs_after_restore` function now calls the `publish` method directly on the `graph` object, passing the `system_user` and notes. This simplifies the code by using the existing `publish` method of the `Graph` model.

### Import Adjustments:
* Added import for `User` and `Graph` models from `django.contrib.auth.models` and `arches.app.models.graph` respectively, to replace the previous dynamic model retrieval using `apps.get_model`.

### Error Handling:
* The new implementation includes a try-except block to handle any exceptions that occur during the publishing process, raising an `UnpublishedModelError` if an error is encountered.