### PR TITLE
Remove exclusion of system settings graph from publishing after restore AB#84748

### DIFF
--- a/mariner_proj/migrations/84748_publish_graphs_after_restore.py
+++ b/mariner_proj/migrations/84748_publish_graphs_after_restore.py
@@ -18,8 +18,6 @@ def publish_graphs_after_restore(apps, schema_editor):
     """
     Publish all graphs after restore
     """
-    system_settings_id = settings.SYSTEM_SETTINGS_RESOURCE_MODEL_ID
-
     try:
         system_user = User.objects.get(username="admin")
     except User.DoesNotExist:
@@ -30,7 +28,7 @@ def publish_graphs_after_restore(apps, schema_editor):
 
     graphs_to_publish = Graph.objects.filter(
         isresource=True, publication__isnull=True
-    ).exclude(graphid=system_settings_id)
+    )
 
     for graph in graphs_to_publish:
         try:

--- a/mariner_proj/migrations/84748_publish_graphs_after_restore.py
+++ b/mariner_proj/migrations/84748_publish_graphs_after_restore.py
@@ -26,9 +26,7 @@ def publish_graphs_after_restore(apps, schema_editor):
         if not system_user:
             raise Exception("No superuser found to publish graphs.")
 
-    graphs_to_publish = Graph.objects.filter(
-        isresource=True, publication__isnull=True
-    )
+    graphs_to_publish = Graph.objects.filter(isresource=True, publication__isnull=True)
 
     for graph in graphs_to_publish:
         try:


### PR DESCRIPTION
This pull request includes changes to the `publish_graphs_after_restore` function in the `mariner_proj/migrations/84748_publish_graphs_after_restore.py` file. The changes focus on simplifying the code by removing an unused variable and its associated filtering logic.

Code simplification:

* [`mariner_proj/migrations/84748_publish_graphs_after_restore.py`](diffhunk://#diff-06a65f7a2e35b97e2fdc789821d4b25b23b90cdbbf3bedd6b9dff5766064b4ddL21-L22): Removed the `system_settings_id` variable and its usage in the `exclude` method when filtering graphs to publish. [[1]](diffhunk://#diff-06a65f7a2e35b97e2fdc789821d4b25b23b90cdbbf3bedd6b9dff5766064b4ddL21-L22) [[2]](diffhunk://#diff-06a65f7a2e35b97e2fdc789821d4b25b23b90cdbbf3bedd6b9dff5766064b4ddL33-R31)