### PR TITLE
AB#84212 mariner initial spatialviews

### DIFF
--- a/mariner_proj/migrations/84212_mariner_initial_spatialviews.py
+++ b/mariner_proj/migrations/84212_mariner_initial_spatialviews.py
@@ -55,6 +55,26 @@ def load_spatialviews(apps, schema_editor):
             "language_id": "en",
         },
         {
+            "spatialviewid": UUID("697a8dd6-70e3-47f7-ac6b-e704f8ea1a69"),
+            "schema": "public",
+            "slug": "artefact",
+            "description": "Defines information relating to the character of man made items of heritage significance. Includes individual artefacts, architectural items, artefact assemblages, individual ecofacts and ecofact assemblages, and environmental samples. Last updated: January 2024",
+            "ismixedgeometrytypes": False,
+            "attributenodes": [
+                {
+                    "nodeid": "1d49ee68-2d51-11ef-ae46-0242ac140006",
+                    "description": "artefact_name",
+                },
+                {
+                    "nodeid": "1d4a56be-2d51-11ef-ae46-0242ac140006",
+                    "description": "primary_reference_number",
+                },
+            ],
+            "isactive": True,
+            "geometrynode_id": UUID("1d49c9c4-2d51-11ef-ae46-0242ac140006"),
+            "language_id": "en",
+        },
+        {
             "spatialviewid": UUID("7bfe40d2-0faa-427b-b565-87a46cc05d27"),
             "schema": "public",
             "slug": "climate_hazard",
@@ -341,6 +361,7 @@ def unload_spatialviews(apps, schema_editor):
     spatialviewids = [
         UUID("a15ac9f1-3b8b-4c30-9872-0a5a9a89b2e8"),
         UUID("747a8dd6-70e3-47f7-ac6b-e704f8ea1a43"),
+        UUID("697a8dd6-70e3-47f7-ac6b-e704f8ea1a69"),
         UUID("7bfe40d2-0faa-427b-b565-87a46cc05d27"),
         UUID("011d068a-14db-41f4-b9cb-b2a3ed56995c"),
         UUID("36a16183-67f9-40dd-863a-770cbfaed5ac"),


### PR DESCRIPTION
[AB#84212](https://hedev.visualstudio.com/76e71f30-b1ad-438a-a096-89ac98712f4e/_workitems/edit/84212)

This pull request introduces a migration script in `mariner_proj/migrations/84212_mariner_initial_spatialviews.py` to populate the `SpatialView` model with predefined spatial view records. It includes robust error handling for scenarios where the database setup is incomplete or testing environments lack necessary data. Additionally, it ensures safe insertion by verifying the existence of associated geometry nodes.

### Migration Script Enhancements:

* **Data Population:** Adds a function `load_spatialviews` to populate the `SpatialView` model with predefined records, including detailed metadata such as descriptions, attribute nodes, and geometry node associations.
* **Error Handling:** Implements error handling for missing models (`SpatialView` and `Node`) and database exceptions during insertion or update operations. Debug messages are logged for skipped records or failed operations.
* **Geometry Node Validation:** Checks the existence of `geometrynode_id` in the `Node` model before inserting records to ensure data integrity.

### Reverse Migration:

* **Data Removal:** Adds a function `unload_spatialviews` to safely delete the predefined spatial view records using their `spatialviewid` values.

### Migration Class:

* **Dependencies and Operations:** Defines the migration's dependency on `84748_publish_graphs_after_restore` and registers the `load_spatialviews`