### PR TITLE
AB#99743 Add skip to content link upon first tab

### DIFF
--- a/mariner_proj/media/css/project-files/_landing.scss
+++ b/mariner_proj/media/css/project-files/_landing.scss
@@ -12,6 +12,34 @@
     font-weight: 300;
     overflow-x: hidden;
     min-width: 100vw;
+    #skip-link-holder a, #skip-link-holder a:link, #skip-link-holder a:visited {
+        color: #000;
+        background-color: #fae619;
+        font-weight: bold;
+        text-decoration: none;
+        padding: 10px;
+        text-align: center;
+        outline: none !important;
+        max-height: 38px;
+        display: block;
+        width: 100%;
+        position: fixed;
+        top: -38px;
+        line-height: 19px;
+        left: 0;
+        z-index: 10001;
+    }
+    #skip-target-holder {
+        position: absolute;
+        top: -38px;
+        left: 0;
+    }
+    #skip-link-holder a:focus, #skip-link-holder a:active {
+        text-decoration: underline !important;
+        left: 0;
+        top: 0;
+        z-index: 10000000;
+    }
     input:focus,
     button:focus,
     .form-control {
@@ -40,7 +68,7 @@
             padding-right: 1.25rem;
         }
     }
-    a:not(.he-button):not(footer a):not(.header-bar__logo-link) {
+    a:not(.he-button):not(footer a):not(.header-bar__logo-link):not(#skip-link-holder a) {
         color: #1a1a1a;
         text-decoration: underline;
         &:hover {

--- a/mariner_proj/templates/index.htm
+++ b/mariner_proj/templates/index.htm
@@ -65,6 +65,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <script src="{% webpack_static 'node_modules/requirejs/require.js' %}"></script>
     {% include 'javascript.htm' %}
 
+    <div id="skip-link-holder"><a id="skip-link" href="#skiptocontent">Skip to content</a></div>
+    
     <!--=== Header ===-->
     <header>
         <nav class="navbar">
@@ -122,6 +124,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <!--=== End Header ===-->
 
     <main>
+        <p id="skip-target-holder">
+            <a id="skiptocontent" name="skiptocontent" tabindex="-1" aria-label="Skip to content" innertext="Start of main content"></a>
+        </p>    
         <article class="container">
             <div class="row featurette1">
                 <div class="featurette1-left-container">


### PR DESCRIPTION
This adds the "Skip to content" link upon first tab press, for the homepage.

Fixes [99743](https://hedev.visualstudio.com/Inventory/_sprints/taskboard/Inventory/Inventory/Inventory/Sprint%20117%20%20-%20xmas%20%F0%9F%8E%85?workitem=99743)