### PR TITLE
AB#100945 AB#100949 Ensure page/tab titles are correct for password reset pages

### DIFF
--- a/mariner_proj/templates/login.htm
+++ b/mariner_proj/templates/login.htm
@@ -56,10 +56,12 @@
 						{% endif %}
 						<button class="he-button" type="submit">{% trans "Sign in" %}</button>
 					</div>
-					<div style="{% if not auth_failed %}display:none;{% endif %}" id="login-failed-alert" class="alert alert-danger fade in" role="alert" aria-live="Assertive">
+					<div style="{% if not auth_failed %}display:none;{% else %}display:block;{% endif %}" id="login-failed-alert" class="alert alert-danger fade in" role="alert" tabindex="0">
 						<button type="button" class="close" data-dismiss="alert" onclick="document.getElementById('login-failed-alert').remove();"><span aria-hidden="true">&times;</span><span class="sr-only">{% trans "Close" %}</span></button>
-						<p class="alert-title">{% trans "Login failed" %}</p>
-						<span role="alert" id="login-fail-message">{% if rate_limited %}{% trans "Too many requests." %}{% else %}{% trans "Invalid username and/or password." %}{% endif %}</span>
+						<div role="alert">
+							<p class="alert-title">{% trans "Login failed" %}</p>
+							<span id="login-fail-message">{% if rate_limited %}{% trans "Too many requests." %}{% else %}{% trans "Invalid username and/or password." %}{% endif %}</span>
+						</div>
 					</div>
 				</fieldset>
 			</form>

--- a/mariner_proj/templates/login.htm
+++ b/mariner_proj/templates/login.htm
@@ -36,6 +36,13 @@
 					<legend class="arches-signin-subtext">
 						{% trans "Sign In" %}
 					</legend>
+					<div style="{% if not auth_failed %}display:none;{% else %}display:block;{% endif %}" id="login-failed-alert" class="alert alert-danger fade in" role="alert" tabindex="0">
+						<button type="button" class="close" data-dismiss="alert" onclick="document.getElementById('login-failed-alert').remove();"><span aria-hidden="true">&times;</span><span class="sr-only">{% trans "Close" %}</span></button>
+						<div role="alert">
+							<p class="alert-title">{% trans "Login failed" %}</p>
+							<span id="login-fail-message">{% if rate_limited %}{% trans "Too many requests." %}{% else %}{% trans "Invalid username and/or password." %}{% endif %}</span>
+						</div>
+					</div>
 					<p>
 						{% trans "Login access to this site is by invitation only. More information on the NMHR is available on <a href=\"https://historicengland.org.uk/research/support-and-collaboration/heritage-information-access-simplified/national-marine-heritage-record/\" target=\"_blank\">our website</a>." %}
 					</p>
@@ -55,13 +62,6 @@
 						<p><a href="{% url 'signup' %}" target="_blank">{% trans "Create a new account" %}</a></p>
 						{% endif %}
 						<button class="he-button" type="submit">{% trans "Sign in" %}</button>
-					</div>
-					<div style="{% if not auth_failed %}display:none;{% else %}display:block;{% endif %}" id="login-failed-alert" class="alert alert-danger fade in" role="alert" tabindex="0">
-						<button type="button" class="close" data-dismiss="alert" onclick="document.getElementById('login-failed-alert').remove();"><span aria-hidden="true">&times;</span><span class="sr-only">{% trans "Close" %}</span></button>
-						<div role="alert">
-							<p class="alert-title">{% trans "Login failed" %}</p>
-							<span id="login-fail-message">{% if rate_limited %}{% trans "Too many requests." %}{% else %}{% trans "Invalid username and/or password." %}{% endif %}</span>
-						</div>
 					</div>
 				</fieldset>
 			</form>

--- a/mariner_proj/templates/login.htm
+++ b/mariner_proj/templates/login.htm
@@ -5,6 +5,8 @@
 {% block loading_mask %}
 {% endblock loading_mask %}
 
+{% block title %}{{ app_settings.APP_NAME }} - Login{% endblock title %}
+
 {% block body %}
 
 <div class="login-container">

--- a/mariner_proj/templates/registration/password_reset_complete.html
+++ b/mariner_proj/templates/registration/password_reset_complete.html
@@ -1,6 +1,8 @@
 {% extends "registration/base.html" %}
 {% load i18n %}
 
+{% block title %}{{ app_settings.APP_NAME }} - Password Reset - Complete{% endblock title %}
+
 {% block content %}
 
 <div class="login-form-container">

--- a/mariner_proj/templates/registration/password_reset_confirm.html
+++ b/mariner_proj/templates/registration/password_reset_confirm.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load template_tags %}
 
+{% block title %}{{ app_settings.APP_NAME }} - Password Reset - Confirm New Password{% endblock title %}
+
 {% block content %}
 
 <div class="login-form-container">

--- a/mariner_proj/templates/registration/password_reset_done.html
+++ b/mariner_proj/templates/registration/password_reset_done.html
@@ -1,6 +1,8 @@
 {% extends "registration/base.html" %}
 {% load i18n %}
 
+{% block title %}{{ app_settings.APP_NAME }} - Password Reset - Link Sent{% endblock title %}
+
 {% block content %}
 
 <div class="login-form-container">

--- a/mariner_proj/templates/registration/password_reset_form.html
+++ b/mariner_proj/templates/registration/password_reset_form.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% load template_tags %}
 
+{% block title %}{{ app_settings.APP_NAME }} - Password Reset{% endblock title %}
+
 {% block content %}
 
 <div class="login-form-container">


### PR DESCRIPTION
These changes add the correct browser tab/page title to all the password reset pages. Also fixes screen reader not reading out the login failure message.

Fixes [100945](https://dev.azure.com/hedev/Inventory/_sprints/taskboard/Inventory/Inventory/Inventory/Sprint%20119?workitem=100945) and [199949](https://dev.azure.com/hedev/Inventory/_workitems/edit/100949)

_PS. Forgive the use of a specific 100945... branch name, but it does encompass both fixes and I didnt want to further confuse by creating additional branches - my bad._