### PR TITLE
AB#104754 Remove back to top button to avoid screen reader announcement

### DIFF
--- a/mariner_proj/media/css/project-files/_general.scss
+++ b/mariner_proj/media/css/project-files/_general.scss
@@ -2,6 +2,8 @@ body {
     font-family: articulat-cf, tahoma, verdana !important;
     letter-spacing: .02em;
     #backToTopBtn {
+        // Temporary fix for back to top button - will be removed when we have a better solution for the button
+        // Core arches issue: https://github.com/archesproject/arches/issues/12720
         display: none !important;
     }
 }

--- a/mariner_proj/media/css/project-files/_general.scss
+++ b/mariner_proj/media/css/project-files/_general.scss
@@ -1,4 +1,7 @@
 body {
     font-family: articulat-cf, tahoma, verdana !important;
     letter-spacing: .02em;
+    #backToTopBtn {
+        display: none !important;
+    }
 }


### PR DESCRIPTION
This was discussed and it was decided to hide the back to top button with display:none!important as it's barely used and not an accessibility requirement. Doing this also means a screen reader will not announce it.

I have created a [core issue here](https://github.com/archesproject/arches/issues/12720), to be revisited one day.