### PR TITLE
AB#98368 Update accessibility statement link

### DIFF
--- a/mariner_proj/templates/base-manager.htm
+++ b/mariner_proj/templates/base-manager.htm
@@ -277,7 +277,7 @@
 
                         <!-- Accessibility -->
                         <li>
-                            <a aria-labelledby="accessibility-link-label" href="https://heazure.sharepoint.com/sites/INT-hub/SitePages/Mariner-Accessibility-Statement.aspx" target="_blank">
+                            <a aria-labelledby="accessibility-link-label" href="https://heazure.sharepoint.com/sites/INT-hub/SitePages/Marine-Historic-Environment-Record-Accessibility-Statement.aspx" target="_blank">
                                 <i class="fa fa-universal-access"></i>
                                 <span class="menu-title">
                                     <strong id="accessibility-link-label">{% trans "Accessibility" %}</strong>

--- a/mariner_proj/templates/index.htm
+++ b/mariner_proj/templates/index.htm
@@ -307,7 +307,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             <div class="container">
                 <div class="footer-container">
                     <div class="col-xs-12 col-sm-8 footer-links">
-                        <a href="https://heazure.sharepoint.com/sites/INT-hub/SitePages/Mariner-Accessibility-Statement.aspx" target="_blank">Accessibility</a>
+                        <a href="https://heazure.sharepoint.com/sites/INT-hub/SitePages/Marine-Historic-Environment-Record-Accessibility-Statement.aspx" target="_blank">Accessibility</a>
                         <a href="#" onclick="CookieControl.open();">Manage Cookies</a>
                         <a href="https://historicengland.org.uk/terms/privacy/" target="_blank">Privacy Policy</a>
                         <a href="https://historicengland.org.uk/terms/" target="_blank">Terms &amp; Conditions</a>

--- a/mariner_proj/templates/login.htm
+++ b/mariner_proj/templates/login.htm
@@ -73,7 +73,7 @@
 			<div class="container">
 				<div class="footer-container">
 					<div class="col-xs-12 col-sm-8 footer-links">
-						<a href="https://heazure.sharepoint.com/sites/INT-hub/SitePages/Mariner-Accessibility-Statement.aspx" target="_blank">Accessibility</a>
+						<a href="https://heazure.sharepoint.com/sites/INT-hub/SitePages/Marine-Historic-Environment-Record-Accessibility-Statement.aspx" target="_blank">Accessibility</a>
 						<a href="#" onclick="CookieControl.open();">Manage Cookies</a>
 						<a href="https://historicengland.org.uk/terms/privacy/" target="_blank">Privacy Policy</a>
 						<a href="https://historicengland.org.uk/terms/" target="_blank">Terms &amp; Conditions</a>

--- a/mariner_proj/templates/registration/base.html
+++ b/mariner_proj/templates/registration/base.html
@@ -51,7 +51,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 			<div class="container">
 				<div class="footer-container">
 					<div class="col-xs-12 col-sm-8 footer-links">
-						<a href="https://heazure.sharepoint.com/sites/INT-hub/SitePages/Mariner-Accessibility-Statement.aspx" target="_blank">Accessibility</a>
+						<a href="https://heazure.sharepoint.com/sites/INT-hub/SitePages/Marine-Historic-Environment-Record-Accessibility-Statement.aspx" target="_blank">Accessibility</a>
 						<a href="#" onclick="CookieControl.open();">Manage Cookies</a>
 						<a href="https://historicengland.org.uk/terms/privacy/" target="_blank">Privacy Policy</a>
 						<a href="https://historicengland.org.uk/terms/" target="_blank">Terms &amp; Conditions</a>


### PR DESCRIPTION
The accessibility statement page name has been updated to reflect the correct name to be Marine-Historic-Environment-Record-Accessibility-Statement. 